### PR TITLE
Removes System.Drawing from IdSharp.Tagging

### DIFF
--- a/IdSharp.Image/AttachedPictureWithImage.cs
+++ b/IdSharp.Image/AttachedPictureWithImage.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using IdSharp.Common.Utils;
+using IdSharp.Tagging.ID3v2.Frames;
+
+
+namespace IdSharp.Tagging.ID3v2.Frames
+{
+    // TODO: Unseal AttachedPicture for this extension to work.
+    /*
+    public class AttachedPictureWithImage : AttachedPicture, IAttachedPictureWithImage
+    {
+        private bool _loadingPicture;
+        private bool _pictureCached;
+        private Image _picture;
+
+        public AttachedPictureWithImage()
+        {
+            this.PropertyChanged += (string name) =>
+            {
+                if (name = nameof(IAttachedPicture.PictureData))
+                {
+                    if (this.PictureData != null)
+                    {
+                        _picture = this.LoadPicture(ref _loadingPicture);
+                        _pictureCached = true;
+                    }
+                }
+            };
+        }
+
+        public Image Picture
+        {
+            get
+            {
+                if (_pictureCached == false)
+                {
+                    _picture = this.LoadPicture(ref _loadingPicture);
+                    _pictureCached = true;
+                }
+
+                return (_picture == null ? null : (Image)_picture.Clone());
+            }
+            set
+            {
+                if (_picture != value)
+                {
+                    if (_picture != null)
+                    {
+                        _picture.Dispose();
+                    }
+
+                    _picture = value;
+
+                    if (value == null)
+                    {
+                        this.PictureData = null;
+                    }
+                    else
+                    {
+                        this.SavePicture(value);
+                    }
+                }
+
+                RaisePropertyChanged("Picture");
+            }
+        }
+
+        public string PictureExtension
+        {
+            get
+            {
+                if (_picture == null)
+                    return null;
+
+                if (_picture.RawFormat.Equals(ImageFormat.Bmp))
+                    return "bmp";
+                else if (_picture.RawFormat.Equals(ImageFormat.Emf))
+                    return "emf";
+                else if (_picture.RawFormat.Equals(ImageFormat.Exif))
+                    return null;  // TODO - Unsure of MIME type?
+                else if (_picture.RawFormat.Equals(ImageFormat.Gif))
+                    return "gif";
+                else if (_picture.RawFormat.Equals(ImageFormat.Icon))
+                    return "ico";
+                else if (_picture.RawFormat.Equals(ImageFormat.Jpeg))
+                    return "jpg";
+                else if (_picture.RawFormat.Equals(ImageFormat.MemoryBmp))
+                    return "bmp";
+                else if (_picture.RawFormat.Equals(ImageFormat.Png))
+                    return "png";
+                else if (_picture.RawFormat.Equals(ImageFormat.Tiff))
+                    return "tif";
+                else if (_picture.RawFormat.Equals(ImageFormat.Wmf))
+                    return "wmf";
+                else
+                    return "";
+            }
+        }
+        */
+    }
+}

--- a/IdSharp.Image/IAttachedPictureExtensions.cs
+++ b/IdSharp.Image/IAttachedPictureExtensions.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using IdSharp.Common.Utils;
+using IdSharp.Tagging.ID3v2.Frames;
+
+
+namespace IdSharp.Tagging.ID3v2.Frames
+{
+    public static class AttachedPictureExtensions
+    {
+        public static void SavePicture(this IAttachedPicture attachedPicture, Image picture)
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                picture.Save(memoryStream, picture.RawFormat);
+                attachedPicture.PictureData = memoryStream.ToArray();
+            }
+
+            SetMimeType(attachedPicture, picture);
+        }
+
+
+        private static void SetMimeType(IAttachedPicture attachedPicture, Image picture)
+        {
+            if (picture != null)
+            {
+                if (picture.RawFormat.Equals(ImageFormat.Bmp))
+                {
+                    attachedPicture.MimeType = "image/bmp";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Emf))
+                {
+                    attachedPicture.MimeType = "image/x-emf";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Exif))
+                {
+                    // TODO - Unsure of MIME type?
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Gif))
+                {
+                    attachedPicture.MimeType = "image/gif";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Icon))
+                {
+                    // TODO - How to handle this?
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Jpeg))
+                {
+                    attachedPicture.MimeType = "image/jpeg";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.MemoryBmp))
+                {
+                    attachedPicture.MimeType = "image/bmp";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Png))
+                {
+                    attachedPicture.MimeType = "image/png";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Tiff))
+                {
+                    attachedPicture.MimeType = "image/tiff";
+                }
+                else if (picture.RawFormat.Equals(ImageFormat.Wmf))
+                {
+                    attachedPicture.MimeType = "image/x-wmf";
+                }
+                else
+                {
+                    // TODO
+                    //attachedPicture.MimeType = "image/";
+                }
+            }
+        }
+
+        public static Image LoadPicture(this IAttachedPicture attachedPicture)
+        {
+            bool _ = false;
+            return LoadPicture(attachedPicture, ref _);
+        }
+
+        public static Image LoadPicture(IAttachedPicture picture, ref bool loadingPicture)
+        {
+            loadingPicture = false;
+
+            var _pictureData = picture.PictureData;
+            if (_pictureData == null)
+            {
+                return null;
+            }
+
+            using (MemoryStream memoryStream = new MemoryStream(_pictureData))
+            {
+                bool isInvalidImage = false;
+                Image image = null;
+                try
+                {
+                    loadingPicture = true;
+                    try
+                    {
+                        image = Image.FromStream(memoryStream);
+                    }
+                    finally
+                    {
+                        loadingPicture = false;
+                    }
+                }
+                catch (OutOfMemoryException)
+                {
+                    string msg = string.Format("OutOfMemoryException caught in APIC's PictureData setter");
+                    Trace.WriteLine(msg);
+
+                    isInvalidImage = true;
+                }
+                catch (ArgumentException)
+                {
+                    string msg = string.Format("ArgumentException caught in APIC's PictureData setter");
+                    Trace.WriteLine(msg);
+
+                    isInvalidImage = true;
+                }
+
+                if (isInvalidImage)
+                {
+                    // Invalid image
+                    if (image != null)
+                    {
+                        image.Dispose();
+                    }
+
+                    image = null;
+                    try
+                    {
+                        string url = ByteUtils.ISO88591GetString(_pictureData);
+                        if (url.Contains("://"))
+                        {
+                            picture.MimeType = "-->";
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // don't throw an exception
+                        Trace.WriteLine(ex);
+                    }
+                }
+
+                return image;
+            }
+        }
+    }
+
+
+
+}

--- a/IdSharp.Image/IAttachedPictureWithImage.cs
+++ b/IdSharp.Image/IAttachedPictureWithImage.cs
@@ -1,0 +1,19 @@
+﻿using System.Drawing;
+
+namespace IdSharp.Tagging.ID3v2.Frames
+{
+    public interface IAttachedPictureWithImage : IAttachedPicture
+    {
+        /// <summary>
+        /// Gets or sets the picture.
+        /// </summary>
+        /// <value>The picture.</value>
+        Image Picture { get; set; }
+
+        /// <summary>
+        /// Gets the picture extension.
+        /// </summary>
+        /// <value>The picture extension.</value>
+        string PictureExtension { get; }
+    }
+}

--- a/IdSharp.Image/IdSharp.Image.csproj
+++ b/IdSharp.Image/IdSharp.Image.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="4.6.0-preview.19073.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IdSharp.Tagging\IdSharp.Tagging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/IdSharp.Tagging/ID3v2/Interfaces/Frames/IAttachedPicture.cs
+++ b/IdSharp.Tagging/ID3v2/Interfaces/Frames/IAttachedPicture.cs
@@ -69,17 +69,5 @@ namespace IdSharp.Tagging.ID3v2.Frames
         /// </summary>
         /// <value>A copy of the raw picture data, or URL.</value>
         byte[] PictureData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the picture.
-        /// </summary>
-        /// <value>The picture.</value>
-        Image Picture { get; set; }
-
-        /// <summary>
-        /// Gets the picture extension.
-        /// </summary>
-        /// <value>The picture extension.</value>
-        string PictureExtension { get; }
     }
 }

--- a/IdSharp.Tagging/IdSharp.Tagging.csproj
+++ b/IdSharp.Tagging/IdSharp.Tagging.csproj
@@ -76,9 +76,6 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="zlib.net">
       <HintPath>Libraries\zlib.net.dll</HintPath>

--- a/IdSharp.sln
+++ b/IdSharp.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdSharp.Example.Console.Tag
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdSharp.Tagging.Tests", "Tests\IdSharp.Tagging.Tests\IdSharp.Tagging.Tests.csproj", "{BE252912-4EEA-424A-BEE1-4EA134D051A6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdSharp.Image", "IdSharp.Image\IdSharp.Image.csproj", "{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,14 @@ Global
 		{BE252912-4EEA-424A-BEE1-4EA134D051A6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BE252912-4EEA-424A-BEE1-4EA134D051A6}.Release|x86.ActiveCfg = Release|Any CPU
 		{BE252912-4EEA-424A-BEE1-4EA134D051A6}.Release|x86.Build.0 = Release|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Debug|x86.Build.0 = Debug|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Release|x86.ActiveCfg = Release|Any CPU
+		{D902D22B-4F6A-4DFA-85A0-3A363D7BCD51}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -120,5 +130,8 @@ Global
 		{C84CCFF5-D059-443B-B913-35A0F73AA2FE} = {4FE79B14-AC9E-45BE-8412-FBD13E7D1F0C}
 		{70C9EC79-F3EB-43A0-B6B1-1C306034A5B7} = {4FE79B14-AC9E-45BE-8412-FBD13E7D1F0C}
 		{BE252912-4EEA-424A-BEE1-4EA134D051A6} = {2BA9EB65-1684-47D1-A477-868048A3CCD0}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69F90366-8D09-4E45-83FE-45BA8DD7E875}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hi! 

Please excuse the direct PR but I figured it was easier to submit a patch with the work done (and to change it if necessary) rather than explain this in an issue.

---

When installing this library via nuget, it also attempt to install System.Drawing (and System.Win32.Events):

![image](https://user-images.githubusercontent.com/1452968/51962117-bae32780-24aa-11e9-9393-6ddfde15ff9c.png)

Coupling this library with System.Drawing for one use case is unnecessary, especially when many libraries have gone to great pains to remove System.Drawing form their stacks.

This commit moves the System.Drawing parts of AttachedPicture into a separate project  so that those references do not pollute the main library.

More work is needed to, especially in deciding whether or not to keep the AttachedPictureWithImage class and possibly publishing a new nuget package as well.

What do you think?